### PR TITLE
🐛 [fix] Scope Squirrel artifact gate to Windows

### DIFF
--- a/scripts/run-packaged-smoke.mjs
+++ b/scripts/run-packaged-smoke.mjs
@@ -258,7 +258,10 @@ export function findForbiddenWindowsPackagingArtifacts(directoryPath) {
             const entryPath = path.join(currentDirectoryPath, entry.name);
             const normalizedName = entry.name.toLowerCase();
             if (
-                normalizedName.includes("squirrel") ||
+                normalizedName === "squirrel.exe" ||
+                normalizedName.includes("squirrel-windows") ||
+                normalizedName.startsWith("fit-file-viewer-squirrel-") ||
+                normalizedName.endsWith(".nupkg") ||
                 normalizedName.endsWith("_executionstub.exe")
             ) {
                 matches.push(entryPath);
@@ -285,7 +288,7 @@ function assertNoForbiddenWindowsPackagingArtifacts(directoryPath) {
 
     throw new Error(
         [
-            "Packaged app contains forbidden Squirrel packaging artifacts:",
+            "Packaged app contains forbidden Squirrel.Windows packaging artifacts:",
             ...forbiddenArtifacts.map((filePath) => `- ${filePath}`),
         ].join("\n")
     );

--- a/tests/unit/packaging/runPackagedSmoke.test.ts
+++ b/tests/unit/packaging/runPackagedSmoke.test.ts
@@ -134,66 +134,53 @@ describe("run-packaged-smoke script", () => {
         ).toThrow("Packaged Electron executable not found");
     });
 
-    it("rejects Squirrel.Windows artifacts without rejecting Electron's macOS updater framework", () => {
-        expect.assertions(3);
+    it("finds known Squirrel.Windows package artifacts", () => {
+        expect.assertions(1);
 
         const releaseDistPath = createTemporaryRoot();
-        const macSquirrelFrameworkPath = path.join(
-            releaseDistPath,
-            "mac-arm64",
-            "Fit File Viewer.app",
-            "Contents",
-            "Frameworks",
-            "Squirrel.framework"
-        );
-        const squirrelDirectoryPath = path.join(
-            releaseDistPath,
-            "squirrel-windows"
-        );
+        const forbiddenPaths = [
+            path.join(releaseDistPath, "squirrel-windows"),
+            path.join(
+                releaseDistPath,
+                "win-unpacked",
+                "Fit File Viewer_ExecutionStub.exe"
+            ),
+            path.join(releaseDistPath, "win-unpacked", "Squirrel.exe"),
+            path.join(releaseDistPath, "FitFileViewer-30.0.1-full.nupkg"),
+            path.join(
+                releaseDistPath,
+                "Fit-File-Viewer-squirrel-x64-30.0.1.exe"
+            ),
+        ];
+        mkdirSync(forbiddenPaths[0], { recursive: true });
+        for (const forbiddenPath of forbiddenPaths.slice(1)) {
+            writeExecutable(forbiddenPath);
+        }
+
+        expect(
+            findForbiddenWindowsPackagingArtifacts(releaseDistPath)
+        ).toStrictEqual(forbiddenPaths.sort());
+    });
+
+    it("rejects Squirrel.Windows artifacts before launching an app", () => {
+        expect.assertions(2);
+
+        const releaseDistPath = createTemporaryRoot();
         const executablePath = path.join(
             releaseDistPath,
             "win-unpacked",
             "Fit File Viewer.exe"
         );
-        const executionStubPath = path.join(
-            releaseDistPath,
-            "win-unpacked",
-            "Fit File Viewer_ExecutionStub.exe"
-        );
-        const squirrelExecutablePath = path.join(
-            releaseDistPath,
-            "win-unpacked",
-            "Squirrel.exe"
-        );
-        const squirrelPackagePath = path.join(
-            releaseDistPath,
-            "FitFileViewer-30.0.1-full.nupkg"
-        );
-        const renamedSquirrelInstallerPath = path.join(
-            releaseDistPath,
-            "Fit-File-Viewer-squirrel-x64-30.0.1.exe"
-        );
-        mkdirSync(macSquirrelFrameworkPath, { recursive: true });
-        mkdirSync(squirrelDirectoryPath, { recursive: true });
         writeExecutable(executablePath);
-        writeExecutable(executionStubPath);
-        writeExecutable(squirrelExecutablePath);
-        writeExecutable(renamedSquirrelInstallerPath);
-        writeFileSync(squirrelPackagePath, "Squirrel.Windows package");
-
+        writeExecutable(
+            path.join(
+                releaseDistPath,
+                "win-unpacked",
+                "Fit File Viewer_ExecutionStub.exe"
+            )
+        );
         const commandRunner = vi.fn<CommandRunner>();
 
-        expect(
-            findForbiddenWindowsPackagingArtifacts(releaseDistPath)
-        ).toStrictEqual(
-            [
-                executionStubPath,
-                renamedSquirrelInstallerPath,
-                squirrelDirectoryPath,
-                squirrelExecutablePath,
-                squirrelPackagePath,
-            ].sort()
-        );
         expect(() =>
             runPackagedSmoke(
                 ["--executable", executablePath],
@@ -202,6 +189,27 @@ describe("run-packaged-smoke script", () => {
             )
         ).toThrow("forbidden Squirrel.Windows packaging artifacts");
         expect(commandRunner).not.toHaveBeenCalled();
+    });
+
+    it("allows Electron's macOS Squirrel updater framework", () => {
+        expect.assertions(1);
+
+        const releaseDistPath = createTemporaryRoot();
+        mkdirSync(
+            path.join(
+                releaseDistPath,
+                "mac-arm64",
+                "Fit File Viewer.app",
+                "Contents",
+                "Frameworks",
+                "Squirrel.framework"
+            ),
+            { recursive: true }
+        );
+
+        expect(
+            findForbiddenWindowsPackagingArtifacts(releaseDistPath)
+        ).toStrictEqual([]);
     });
 
     it("launches the packaged executable and treats timeout as a healthy startup", () => {

--- a/tests/unit/packaging/runPackagedSmoke.test.ts
+++ b/tests/unit/packaging/runPackagedSmoke.test.ts
@@ -134,10 +134,18 @@ describe("run-packaged-smoke script", () => {
         ).toThrow("Packaged Electron executable not found");
     });
 
-    it("rejects Squirrel artifacts or helper executables leaked into Windows packages", () => {
+    it("rejects Squirrel.Windows artifacts without rejecting Electron's macOS updater framework", () => {
         expect.assertions(3);
 
         const releaseDistPath = createTemporaryRoot();
+        const macSquirrelFrameworkPath = path.join(
+            releaseDistPath,
+            "mac-arm64",
+            "Fit File Viewer.app",
+            "Contents",
+            "Frameworks",
+            "Squirrel.framework"
+        );
         const squirrelDirectoryPath = path.join(
             releaseDistPath,
             "squirrel-windows"
@@ -152,22 +160,47 @@ describe("run-packaged-smoke script", () => {
             "win-unpacked",
             "Fit File Viewer_ExecutionStub.exe"
         );
+        const squirrelExecutablePath = path.join(
+            releaseDistPath,
+            "win-unpacked",
+            "Squirrel.exe"
+        );
+        const squirrelPackagePath = path.join(
+            releaseDistPath,
+            "FitFileViewer-30.0.1-full.nupkg"
+        );
+        const renamedSquirrelInstallerPath = path.join(
+            releaseDistPath,
+            "Fit-File-Viewer-squirrel-x64-30.0.1.exe"
+        );
+        mkdirSync(macSquirrelFrameworkPath, { recursive: true });
         mkdirSync(squirrelDirectoryPath, { recursive: true });
         writeExecutable(executablePath);
         writeExecutable(executionStubPath);
+        writeExecutable(squirrelExecutablePath);
+        writeExecutable(renamedSquirrelInstallerPath);
+        writeFileSync(squirrelPackagePath, "Squirrel.Windows package");
 
         const commandRunner = vi.fn<CommandRunner>();
 
         expect(
             findForbiddenWindowsPackagingArtifacts(releaseDistPath)
-        ).toStrictEqual([executionStubPath, squirrelDirectoryPath].sort());
+        ).toStrictEqual(
+            [
+                executionStubPath,
+                renamedSquirrelInstallerPath,
+                squirrelDirectoryPath,
+                squirrelExecutablePath,
+                squirrelPackagePath,
+            ].sort()
+        );
         expect(() =>
             runPackagedSmoke(
                 ["--executable", executablePath],
                 {},
                 commandRunner
             )
-        ).toThrow("forbidden Squirrel packaging artifacts");
+        ).toThrow("forbidden Squirrel.Windows packaging artifacts");
         expect(commandRunner).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary

- scope the packaged-artifact guard to Squirrel.Windows outputs
- preserve Electron's legitimate macOS `Squirrel.framework`
- cover Windows helper, package, directory, and renamed-installer leakage in the regression test

## Why

The first unpublished v30.0.2 release run correctly removed Squirrel.Windows from the Windows builds, but the new cross-platform artifact guard also matched Electron's bundled macOS updater framework. This keeps the Windows protection while allowing the supported macOS runtime component.

## Verification

- `node --max-old-space-size=8192 ./node_modules/vitest/vitest.mjs --config vitest.config.ts --run tests/unit/packaging/runPackagedSmoke.test.ts tests/unit/packaging/electronBuilderConfig.test.ts --maxWorkers 1`
- `npx prettier --check scripts/run-packaged-smoke.mjs tests/unit/packaging/runPackagedSmoke.test.ts`
- `npx eslint scripts/run-packaged-smoke.mjs tests/unit/packaging/runPackagedSmoke.test.ts`
- `git diff --check`

## Release recovery

No GitHub release was published. After this merges and required checks pass, the unpublished `v30.0.2` tag will be moved from the failed version-bump commit to the repaired `main` commit, then the release workflow's explicit `reuse-current-version` path will be used.