### PR TITLE
🔒 [ci] Make VirusTotal scans fail closed

### DIFF
--- a/.github/workflows/VirusTotal.yml
+++ b/.github/workflows/VirusTotal.yml
@@ -1,5 +1,6 @@
-# This workflow scans distributable files in release-dist/ with VirusTotal after every push to main or manual dispatch.
-# It uses the crazy-max/ghaction-virustotal action and your provided API key (should be stored as a secret in production).
+# Scan published release assets with VirusTotal after a successful release or a
+# manual dispatch.
+# VT_API_KEY must be configured as a repository secret.
 
 name: Virus Total Scan
 run-name: Virus Total Scan (${{ github.ref_name }})
@@ -43,7 +44,4 @@ jobs:
               uses: crazy-max/ghaction-virustotal@936d8c5c00afe97d3d9a1af26d017cfdf26800a2 # v5.0.0
               with:
                   vt_api_key: ${{ secrets.VT_API_KEY }}
-                  files: |
-                      release-dist/*
-                      release-dist/**/*
-              continue-on-error: true
+                  files: release-dist/*


### PR DESCRIPTION
## Summary

- submit each downloaded release asset to VirusTotal once
- remove `continue-on-error` so upload/API failures fail the job
- correct the workflow header to match its actual triggers and secret requirement

## Why

The v30.0.2 post-release scan selected 66 flat release assets through two overlapping globs, reported 132 files, then ended with a duplicate-submission HTTP 409. The scan step was configured to continue on error, so GitHub displayed a successful workflow despite the logged error.

The release downloader stores all assets directly under `release-dist`, so `release-dist/*` is the complete non-duplicated selection.

## Verification

- `actionlint .github/workflows/VirusTotal.yml`
- `yamllint -c .yamllint.yaml .github/workflows/VirusTotal.yml` (four pre-existing long pinned-action lines remain warnings)
- `npx prettier --check .github/workflows/VirusTotal.yml`
- `git diff --check`

This CI-only change does not modify the already-published v30.0.2 artifacts.